### PR TITLE
Add the ability to playback recorded video : issue#3

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,7 +43,7 @@ services:
       - 80:80
     tty: true
     volumes:
-      - ./data:/data
+      - ./data:/usr/share/nginx/html
       - ./log/nginx_rtmp/:/var/log/nginx/
     healthcheck:
       test: "(curl -s -S -o /dev/null -f http://nginx_rtmp/hls/c110.m3u8 && curl -s -S -o /dev/null -f http://nginx_rtmp/hls/c200.m3u8) || exit 1 "
@@ -53,4 +53,10 @@ services:
       start_period: 15s
     restart: always
 
+  php_fpm:
+    container_name: php_fpm
+    build: ./php_fpm
+    restart: always
+    volumes:
+      - ./data:/usr/share/nginx/html
   

--- a/data/c110.html
+++ b/data/c110.html
@@ -32,7 +32,7 @@
                 <b-iconstack font-scale="1.5">
                     <b-icon stacked icon="stop-fill" variant="danger"></b-icon>
                     <b-icon stacked icon="circle" variant="danger"></b-icon>
-                </b-iconstack> Recoding Stop
+                </b-iconstack> Recording Stop
             </b-button>
         </b-container>
     </div>

--- a/data/c200.html
+++ b/data/c200.html
@@ -33,7 +33,7 @@
                 <b-iconstack font-scale="1.5">
                     <b-icon stacked icon="stop-fill" variant="danger"></b-icon>
                     <b-icon stacked icon="circle" variant="danger"></b-icon>
-                </b-iconstack> Recoding Stop
+                </b-iconstack> Recording Stop
             </b-button>
         </b-container>
     </div>

--- a/data/index.php
+++ b/data/index.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Recording Lists</title>
+</head>
+<body>
+    <h1>Video Lists</h1>
+    <p>録画した映像の一覧です</p>
+    <?php $mp4files = glob('hls/*.mp4'); ?>
+    <?php foreach( $mp4files as $file) : ?>
+    <video controls playsinline muted preload="metadata" width="640">
+        <source src="<?php echo $file; ?>">
+    </video>
+    <?php endforeach; ?>
+</body>
+</html>

--- a/nginx_rtmp/Dockerfile
+++ b/nginx_rtmp/Dockerfile
@@ -4,15 +4,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ="Asia/Tokyo"
 
 RUN apt-get update && \
-    apt-get install -yq tzdata nginx libnginx-mod-rtmp curl && \
+    apt-get install -yq tzdata nginx libnginx-mod-rtmp curl ffmpeg && \
     rm -rf /var/lib/apt/lists/* && \
     ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
     dpkg-reconfigure tzdata
 
-RUN mkdir -p /data && \
-    chown -R www-data:www-data /data 
 COPY etc/nginx/conf/nginx.conf /etc/nginx/nginx.conf
-#COPY www/*.html /data/
 
 EXPOSE 1935
 EXPOSE 80

--- a/nginx_rtmp/etc/nginx/conf/nginx.conf
+++ b/nginx_rtmp/etc/nginx/conf/nginx.conf
@@ -1,5 +1,4 @@
-user www-data;
-#worker_processes auto;
+user www-data www-data;
 worker_processes 1;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
@@ -14,21 +13,31 @@ http {
     default_type application/octet-stream;
     server { 
         listen 80;
+        root /usr/share/nginx/html;
+
         location / { 
-            root /data;
+            index index.php index.html;
+            include /etc/nginx/mime.types;
             add_header Cache-Control no-cache;  
         } 
 
         location /control {
             rtmp_control all;
         }
+
+        location ~ \.php$ {
+            fastcgi_pass php_fpm:9000;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            include fastcgi_params;
+        }
     }
-    types {
-        application/vnd.apple.mpegurl m3u8;
-        video/mp2t ts;
-        text/html html;
+    #types {
+    #    application/vnd.apple.mpegurl m3u8;
+    #    video/mp2t ts;
+    #    text/html html;
         #application/dash+xml mpd;
-    } 
+    #} 
 }
 
 rtmp { 
@@ -38,7 +47,7 @@ rtmp {
             live on; 
             interleave on;
             hls on; 
-            hls_path /data/hls;
+            hls_path /usr/share/nginx/html/hls;
             hls_fragment 5s;
             hls_playlist_length 10s;
             #dash on;
@@ -48,9 +57,9 @@ rtmp {
             recorder rec1 {
                 record all manual;
                 record_suffix -%Y%m%d%H%M%S.flv;
-                record_path /data/hls;
+                record_path /usr/share/nginx/html/hls;
                 record_unique on;
-                #record_notify on;
+                exec_record_done ffmpeg -i $path -vcodec copy $dirname/$basename.mp4;
             }
         }
     } 

--- a/php_fpm/Dockerfile
+++ b/php_fpm/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.2-fpm
+
+# RUN apt-get update && \
+#     apt-get install -y libonig-dev && \
+#     docker-php-ext-install mbstring
+
+RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+COPY settings/php.ini /usr/local/etc/php/conf.d/php.ini
+COPY settings/www.conf /usr/local/etc/php-fpm.d/www.conf

--- a/php_fpm/settings/php.ini
+++ b/php_fpm/settings/php.ini
@@ -1,0 +1,23 @@
+# php.ini の内容
+[PHP]
+;;;;;;;;;;;;;;;;;
+; Data Handling ;
+;;;;;;;;;;;;;;;;;
+
+post_max_size = 20M
+
+;;;;;;;;;;;;;;;;
+; File Uploads ;
+;;;;;;;;;;;;;;;;
+
+upload_max_filesize = 20M
+
+;;;;;;;;;;;;;;;;;;;
+; Module Settings ;
+;;;;;;;;;;;;;;;;;;;
+
+[Date]
+date.timezone = Asia/Tokyo
+
+[mbstring]
+mbstring.language = Japanese

--- a/php_fpm/settings/www.conf
+++ b/php_fpm/settings/www.conf
@@ -1,0 +1,11 @@
+[www]
+user = www-data
+group = www-data
+listen = 127.0.0.1:9000
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+security.limit_extensions = .php .html
+php_admin_value[error_log] = /var/log/fpm-php.www.log


### PR DESCRIPTION
* Container Build Result
```
$ docker compose up -d --build
[+] Building 3.8s (33/33) FINISHED                                                                                         
 => [php_fpm internal] load .dockerignore                                                                             0.3s
 => => transferring context: 2B                                                                                       0.0s
 => [php_fpm internal] load build definition from Dockerfile                                                          0.2s
 => => transferring dockerfile: 349B                                                                                  0.0s
 => [nginx_rtmp internal] load build definition from Dockerfile                                                       0.4s
 => => transferring dockerfile: 452B                                                                                  0.0s
 => [nginx_rtmp internal] load .dockerignore                                                                          0.3s
 => => transferring context: 2B                                                                                       0.0s
 => [php_fpm internal] load metadata for docker.io/library/php:8.2-fpm                                                1.0s
 => [nginx_rtmp internal] load metadata for docker.io/library/ubuntu:22.04                                            0.0s
 => [nginx_rtmp 1/3] FROM docker.io/library/ubuntu:22.04                                                              0.0s
 => [nginx_rtmp internal] load build context                                                                          0.1s
 => => transferring context: 133B                                                                                     0.0s
 => CACHED [nginx_rtmp 2/3] RUN apt-get update &&     apt-get install -yq tzdata nginx libnginx-mod-rtmp curl ffmpeg  0.0s
 => CACHED [nginx_rtmp 3/3] COPY etc/nginx/conf/nginx.conf /etc/nginx/nginx.conf                                      0.0s
 => [nginx_rtmp] exporting to image                                                                                   0.1s
 => => exporting layers                                                                                               0.0s
 => => writing image sha256:3e1d4c3b00ac66cd2a1d00392b10555fa36b420417d4e15414b60b0902485355                          0.0s
 => => naming to docker.io/library/http-live-streaming-of-rtsp-cameras-nginx_rtmp                                     0.0s
 => [php_fpm 1/4] FROM docker.io/library/php:8.2-fpm@sha256:bc5b874d269334221c8ca8283037a2df224b96d8b8dca84eb2f98f76  0.0s
 => [php_fpm internal] load build context                                                                             0.5s
 => => transferring context: 103B                                                                                     0.0s
 => [camera_c110 internal] load build definition from Dockerfile                                                      0.3s
 => => transferring dockerfile: 258B                                                                                  0.0s
 => [camera_c110 internal] load .dockerignore                                                                         0.3s
 => => transferring context: 2B                                                                                       0.0s
 => [camera_c200 internal] load build definition from Dockerfile                                                      0.2s
 => => transferring dockerfile: 258B                                                                                  0.0s
 => [camera_c200 internal] load .dockerignore                                                                         0.2s
 => => transferring context: 2B                                                                                       0.0s
 => CACHED [php_fpm 2/4] RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini                      0.0s
 => CACHED [php_fpm 3/4] COPY settings/php.ini /usr/local/etc/php/conf.d/php.ini                                      0.0s
 => CACHED [php_fpm 4/4] COPY settings/www.conf /usr/local/etc/php-fpm.d/www.conf                                     0.1s
 => [camera_c200 internal] load metadata for docker.io/jrottenberg/ffmpeg:4.1-alpine                                  0.0s
 => [camera_c200 1/5] FROM docker.io/jrottenberg/ffmpeg:4.1-alpine                                                    0.0s
 => [camera_c110 internal] load build context                                                                         0.2s
 => => transferring context: 32B                                                                                      0.0s
 => [php_fpm] exporting to image                                                                                      0.1s
 => => exporting layers                                                                                               0.0s
 => => writing image sha256:28abf47e3b1fa2b7b8363f144fbd7eb3e99fe74281abf13d5f32a49a32ee1259                          0.0s
 => => naming to docker.io/library/http-live-streaming-of-rtsp-cameras-php_fpm                                        0.0s
 => [camera_c200 internal] load build context                                                                         0.2s
 => => transferring context: 32B                                                                                      0.0s
 => CACHED [camera_c200 2/5] RUN adduser --disabled-password ffmpeg                                                   0.0s
 => CACHED [camera_c200 3/5] WORKDIR /home/ffmpeg                                                                     0.0s
 => CACHED [camera_c110 4/5] COPY convert.sh .                                                                        0.0s
 => CACHED [camera_c110 5/5] RUN chmod +x convert.sh     && chown ffmpeg:ffmpeg convert.sh                            0.0s
 => [camera_c110] exporting to image                                                                                  0.1s
 => => exporting layers                                                                                               0.0s
 => => writing image sha256:971db8ed0a4482457da302f325244d483d7468ba2390c6165fb39ed99eed5f2d                          0.0s
 => => naming to docker.io/library/http-live-streaming-of-rtsp-cameras-camera_c110                                    0.1s
 => CACHED [camera_c200 4/5] COPY convert.sh .                                                                        0.0s
 => CACHED [camera_c200 5/5] RUN chmod +x convert.sh     && chown ffmpeg:ffmpeg convert.sh                            0.0s
 => [camera_c200] exporting to image                                                                                  0.1s
 => => exporting layers                                                                                               0.0s
 => => writing image sha256:8d0305fe6a7869cd729e48067f495117a6e2221992e5d2976337e98f480f3973                          0.0s
 => => naming to docker.io/library/http-live-streaming-of-rtsp-cameras-camera_c200                                    0.0s
[+] Running 4/0
 ✔ Container php_fpm      Running                                                                                     0.0s 
 ✔ Container nginx_rtmp   Running                                                                                     0.0s 
 ✔ Container camera_c110  Running                                                                                     0.0s 
 ✔ Container camera_c200  Running                                                                                     0.0s
```
* Container running
```
$ docker compose ps
NAME                IMAGE                                             COMMAND                  SERVICE             CREATED             STATUS                    PORTS
camera_c110         http-live-streaming-of-rtsp-cameras-camera_c110   "/bin/sh -c 'exec /h…"   camera_c110         50 seconds ago      Up 44 seconds (healthy)   
camera_c200         http-live-streaming-of-rtsp-cameras-camera_c200   "/bin/sh -c 'exec /h…"   camera_c200         50 seconds ago      Up 44 seconds (healthy)   
nginx_rtmp          http-live-streaming-of-rtsp-cameras-nginx_rtmp    "nginx -g 'daemon of…"   nginx_rtmp          55 seconds ago      Up 45 seconds (healthy)   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:32830->1935/tcp, :::32830->1935/tcp
php_fpm             http-live-streaming-of-rtsp-cameras-php_fpm       "docker-php-entrypoi…"   php_fpm             15 seconds ago      Up 11 seconds             9000/tcp
```
* Logs of Containers
```
$ docker compose logs
camera_c200  | ffmpeg version 4.1.10 Copyright (c) 2000-2022 the FFmpeg developers
camera_c200  |   built with gcc 10.2.1 (Alpine 10.2.1_pre1) 20201203
camera_c200  |   configuration: --disable-debug --disable-doc --disable-ffplay --enable-avresample --enable-fontconfig --enable-gpl --enable-libaom --enable-libass --enable-libbluray --enable-libfdk_aac --enable-libfreetype --enable-libkvazaar --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopus --enable-libsrt --enable-libtheora --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxvid --enable-libzmq --enable-nonfree --enable-openssl --enable-postproc --enable-shared --enable-small --enable-version3 --extra-cflags=-I/opt/ffmpeg/include --extra-ldflags=-L/opt/ffmpeg/lib --extra-libs=-ldl --extra-libs=-lpthread --prefix=/opt/ffmpeg
camera_c200  |   libavutil      56. 22.100 / 56. 22.100
camera_c110  | ffmpeg version 4.1.10 Copyright (c) 2000-2022 the FFmpeg developers
camera_c110  |   built with gcc 10.2.1 (Alpine 10.2.1_pre1) 20201203
camera_c110  |   configuration: --disable-debug --disable-doc --disable-ffplay --enable-avresample --enable-fontconfig --enable-gpl --enable-libaom --enable-libass --enable-libbluray --enable-libfdk_aac --enable-libfreetype --enable-libkvazaar --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopus --enable-libsrt --enable-libtheora --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxvid --enable-libzmq --enable-nonfree --enable-openssl --enable-postproc --enable-shared --enable-small --enable-version3 --extra-cflags=-I/opt/ffmpeg/include --extra-ldflags=-L/opt/ffmpeg/lib --extra-libs=-ldl --extra-libs=-lpthread --prefix=/opt/ffmpeg
camera_c110  |   libavutil      56. 22.100 / 56. 22.100
camera_c110  |   libavcodec     58. 35.100 / 58. 35.100
camera_c110  |   libavformat    58. 20.100 / 58. 20.100
camera_c110  |   libavdevice    58.  5.100 / 58.  5.100
camera_c110  |   libavfilter     7. 40.101 /  7. 40.101
camera_c110  |   libavresample   4.  0.  0 /  4.  0.  0
camera_c110  |   libswscale      5.  3.100 /  5.  3.100
camera_c200  |   libavcodec     58. 35.100 / 58. 35.100
camera_c200  |   libavformat    58. 20.100 / 58. 20.100
camera_c200  |   libavdevice    58.  5.100 / 58.  5.100
camera_c200  |   libavfilter     7. 40.101 /  7. 40.101
camera_c200  |   libavresample   4.  0.  0 /  4.  0.  0
camera_c200  |   libswscale      5.  3.100 /  5.  3.100
camera_c200  |   libswresample   3.  3.100 /  3.  3.100
camera_c200  |   libpostproc    55.  3.100 / 55.  3.100
camera_c200  | Guessed Channel Layout for Input Stream #0.1 : mono
camera_c200  | Input #0, rtsp, from 'rtsp://lkjhgfdsa:1234567890@192.168.0.101:554/stream2':
camera_c200  |   Metadata:
camera_c200  |     title           : Session streamed by "TP-LINK RTSP Server"
camera_c110  |   libswresample   3.  3.100 /  3.  3.100
camera_c200  |     comment         : stream2
camera_c200  |   Duration: N/A, start: 0.000000, bitrate: N/A
camera_c110  |   libpostproc    55.  3.100 / 55.  3.100
camera_c110  | Guessed Channel Layout for Input Stream #0.1 : mono
camera_c110  | Input #0, rtsp, from 'rtsp://asdfghjkl:1234567890@192.168.0.120:554/stream2':
php_fpm      | [14-Aug-2023 16:02:38] NOTICE: fpm is running, pid 1
camera_c110  |   Metadata:
php_fpm      | [14-Aug-2023 16:02:38] NOTICE: ready to handle connections
camera_c200  |     Stream #0:0: Video: h264, yuv420p(tv, bt709, progressive), 640x360, 15 fps, 16.67 tbr, 90k tbn, 30 tbc
camera_c200  |     Stream #0:1: Audio: pcm_alaw, 8000 Hz, mono, s16, 64 kb/s
camera_c200  | Stream mapping:
camera_c200  |   Stream #0:0 -> #0:0 (h264 (native) -> h264 (libx264))
camera_c110  |     title           : Session streamed by "TP-LINK RTSP Server"
camera_c110  |     comment         : stream2
camera_c110  |   Duration: N/A, start: 0.000000, bitrate: N/A
camera_c110  |     Stream #0:0: Video: h264, yuv420p(progressive), 640x360, 15 fps, 20 tbr, 90k tbn, 30 tbc
camera_c110  |     Stream #0:1: Audio: pcm_alaw, 8000 Hz, mono, s16, 64 kb/s
camera_c110  | Stream mapping:
camera_c110  |   Stream #0:0 -> #0:0 (h264 (native) -> h264 (libx264))
camera_c110  |   Stream #0:1 -> #0:1 (pcm_alaw (native) -> aac (native))
camera_c110  | Press [q] to stop, [?] for help
camera_c110  | [aac @ 0x7fc30dbed040] Too many bits 6408.707483 > 6144 per frame requested, clamping to max
[libx264 @ 0x7fc30dbef040] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 AVX2 LZCNT BMI2peed=N/A    
camera_c110  | [libx264 @ 0x7fc30dbef040] profile High, level 2.2
camera_c110  | [libx264 @ 0x7fc30dbef040] 264 - core 148 - H.264/MPEG-4 AVC codec - Copyleft 2003-2016 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16 chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=11 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=2 keyint=30 keyint_min=3 scenecut=0 intra_refresh=0 rc_lookahead=30 rc=abr mbtree=1 bitrate=512 ratetol=1.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00
camera_c110  | Output #0, flv, to 'rtmp://nginx_rtmp:1935/livecam/c110':
camera_c110  |   Metadata:
camera_c110  |     title           : Session streamed by "TP-LINK RTSP Server"
camera_c110  |     comment         : stream2
camera_c110  |     encoder         : Lavf58.20.100
camera_c110  |     Stream #0:0: Video: h264 (libx264) ([7][0][0][0] / 0x0007), yuv420p, 640x360, q=-1--1, 512 kb/s, 15 fps, 1k tbn, 15 tbc
camera_c110  |     Metadata:
camera_c200  |   Stream #0:1 -> #0:1 (pcm_alaw (native) -> aac (native))
camera_c200  | Press [q] to stop, [?] for help
camera_c200  | [aac @ 0x7fcfc818f040] Too many bits 6408.707483 > 6144 per frame requested, clamping to max
camera_c200  | [libx264 @ 0x7fcfc8191080] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 AVX2 LZCNT BMI2
camera_c200  | [libx264 @ 0x7fcfc8191080] profile High, level 2.2
camera_c200  | [libx264 @ 0x7fcfc8191080] 264 - core 148 - H.264/MPEG-4 AVC codec - Copyleft 2003-2016 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16 chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=11 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=2 keyint=30 keyint_min=3 scenecut=0 intra_refresh=0 rc_lookahead=30 rc=abr mbtree=1 bitrate=512 ratetol=1.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00
camera_c200  | Output #0, flv, to 'rtmp://nginx_rtmp:1935/livecam/c200':
camera_c200  |   Metadata:
camera_c200  |     title           : Session streamed by "TP-LINK RTSP Server"
camera_c200  |     comment         : stream2
camera_c200  |     encoder         : Lavf58.20.100
camera_c200  |     Stream #0:0: Video: h264 (libx264) ([7][0][0][0] / 0x0007), yuv420p, 640x360, q=-1--1, 512 kb/s, 15 fps, 1k tbn, 15 tbc
camera_c200  |     Metadata:
camera_c200  |       encoder         : Lavc58.35.100 libx264
camera_c200  |     Side data:
camera_c200  |       cpb: bitrate max/min/avg: 0/0/512000 buffer size: 0 vbv_delay: -1
camera_c200  |     Stream #0:1: Audio: aac ([10][0][0][0] / 0x000A), 11025 Hz, mono, fltp, 66 kb/s
camera_c200  |     Metadata:
camera_c200  |       encoder         : Lavc58.35.100 aac
camera_c110  |       encoder         : Lavc58.35.100 libx264
camera_c110  |     Side data:
camera_c110  |       cpb: bitrate max/min/avg: 0/0/512000 buffer size: 0 vbv_delay: -1
camera_c110  |     Stream #0:1: Audio: aac ([10][0][0][0] / 0x000A), 11025 Hz, mono, fltp, 66 kb/s
camera_c110  |     Metadata:
camera_c110  |       encoder         : Lavc58.35.100 aac
```