### PR TITLE
Issue#12 display stop button after page transition

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -123,7 +123,8 @@
                                     this.requestRecStop();
                                 }, this.autoStopTime);
                             }else if (response.status == '204') {
-                                alert("現在録画中のため、開始できません")
+                                alert("現在録画中のため、開始できません");
+                                this.isRecording=true;
                             }else{
                                 console.log('recording start failed.')
                             }
@@ -147,6 +148,7 @@
                                 this.isRecording=false;
                             }else if (response.status == '204') {
                                 alert("現在録画していないため、停止できません");
+                                this.isRecording=false;
                             }else{
                                 console.log('recording stop failed.');
                             }
@@ -195,6 +197,7 @@
                                 }, this.autoStopTime);
                             }else if (response.status == '204') {
                                 alert("現在録画中のため、開始できません");
+                                this.isRecording=true;
                             }else{
                                 console.log('recording start failed.');
                             }
@@ -218,6 +221,7 @@
                                 this.isRecording=false;
                             }else if (response.status == '204') {
                                 alert("現在録画していないため、停止できません");
+                                this.isRecording=false;
                             }else{
                                 console.log('recording stop failed.');
                             }

--- a/data/index.html
+++ b/data/index.html
@@ -10,6 +10,7 @@
     <link type="text/css" href="https://www.unpkg.com/bootstrap-vue@2.23.1/dist/bootstrap-vue-icons.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/vue@2.7.14/dist/vue.min.js"></script>
     <script src="https://unpkg.com/axios@1.4.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue-spinner@1.0.4/dist/vue-spinner.min.js"></script>
 </head>
 <body>
     <nav class="navbar navbar-expand-lg sticky-top" style="background-color: #ccc;">
@@ -30,7 +31,7 @@
         <div class="container">
             <div class="container">
                 <h3><i class="bi bi-camera-reels me-1"></i>Live Camera Streaming</h3>
-                <p>ネットワークに接続したカメラの映像をライブ配信しています。録画ボタンを押すことで最大30秒間の映像を保存できます。</p>
+                <p>ネットワークに接続したカメラの映像をライブ配信しています。録画ボタンを押すことで最大30秒間もしくは録画ファイルサイズが3MBまでの映像を保存できます。</p>
             </div>
             <div class="row gy-2">
                 <div class="col-lg-6">
@@ -41,14 +42,20 @@
                             HTML5 の video タグをサポートするブラウザを使って下さい。
                         </p>
                     </video-js>
-                    <div class="row text-center" id="app">
-                        <div class="col-lg-4 offset-lg-4 gy-2">
-                            <button v-show="!isRecording" v-on:click="requestRecStart" type="button" class="btn btn-outline-primary mb-2">
-                                <i class="bi bi-record-circle me-1"></i>録画 Start
-                            </button>
-                            <button v-show="isRecording" v-on:click="requestRecStop" type="button" class="btn btn-outline-danger mb-2">
-                                <i class="bi bi-stop-circle me-1"></i>録画 Stop
-                            </button>
+                    <div id="app">
+                        <div class="row justify-content-md-center text-center">
+                            <div class="col-sm-auto gy-2">
+                                <button v-show="!isRecording" v-on:click="requestRecStart" type="button" class="btn btn-outline-primary mb-2">
+                                    <i class="bi bi-record-fill me-1" style="color: red;"></i>録画 Start
+                                </button>
+                                <div class="justify-content-center" v-show="isRecording">
+                                    <div class="spinner-grow spinner-grow-sm text-danger" role="status"></div>
+                                    <span class="text-dark gy-4 me-2">録画中です...</span>
+                                    <button v-on:click="requestRecStop" type="button" class="col btn btn-outline-primary mb-2">
+                                        <i class="bi bi-stop-circle-fill me-1" style="color: red;"></i>録画 <span style="color: red;">Stop</span>
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -60,14 +67,20 @@
                             HTML5 の video タグをサポートするブラウザを使って下さい。
                         </p>
                     </video-js>
-                    <div class="row text-center" id="app2">
-                        <div class="col-lg-4 offset-lg-4 gy-2">
-                            <button v-show="!isRecording" v-on:click="requestRecStart" type="button" class="btn btn-outline-primary mb-2">
-                                <i class="bi bi-record-circle me-1"></i>録画 Start
-                            </button>
-                            <button v-show="isRecording" v-on:click="requestRecStop" type="button" class="btn btn-outline-danger mb-2">
-                                <i class="bi bi-stop-circle me-1"></i>録画 Stop
-                            </button>
+                    <div id="app2">
+                        <div class="row justify-content-md-center text-center">
+                            <div class="col-sm-auto gy-2">
+                                <button v-show="!isRecording" v-on:click="requestRecStart" type="button" class="btn btn-outline-primary mb-2">
+                                    <i class="bi bi-record-fill me-1" style="color: red;"></i>録画 Start
+                                </button>
+                                <div class="justify-content-center" v-show="isRecording">
+                                    <div class="spinner-grow spinner-grow-sm text-danger" role="status"></div>
+                                    <span class="text-dark gy-4 me-2">録画中です...</span>
+                                    <button v-show="isRecording" v-on:click="requestRecStop" type="button" class="btn btn-outline-primary mb-2">
+                                        <i class="bi bi-stop-circle-fill me-1" style="color: red;"></i>録画 <span style="color: red;">Stop</span>
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -84,7 +97,14 @@
     <script>
         var player = videojs('live-cam');
         var player2 = videojs('live-cam2');
-    </script>
+        window.addEventListener('beforeunload', (event) => {
+            // https://developer.mozilla.org/ja/docs/Web/API/Window/beforeunload_event
+            // Cancel the event as stated by the standard.
+            event.preventDefault();
+            // Chrome requires returnValue to be set.
+            event.returnValue = '';
+        });
+</script>
     <script>
         let app = new Vue({
             el: '#app',
@@ -93,24 +113,15 @@
                     filename: "",
                     isRecording: false,
                     autoStopTime: 30000,
+                    timeoutId: null,
                 }
-            },
-            mounted () {
-                window.addEventListener('beforeunload', () => {
-                    this.requestRecStop()
-                })
-            },
-            destroyed () {
-                window.removeEventListener('beforeunload', () => {
-                    this.requestRecStop()
-                })
             },
             methods: {
                 requestRecStart(){
                     if (this.isRecording) {
-                        console.log('now recording!')
+                        console.log('now recording c110!')
                     } else {
-                        console.log('request start recording')
+                        console.log('request start recording c110')
                         axios
                         .get("control/record/start?app=livecam&name=c110&rec=rec1")
                         .then(response => {
@@ -119,25 +130,30 @@
                             if (response.status == '200') {
                                 this.filename=response.data;
                                 this.isRecording=true;
-                                setTimeout(()=>{
+                                this.timeoutId = setTimeout(()=>{
                                     this.requestRecStop();
                                 }, this.autoStopTime);
+                                console.log('c110 set timeout s:200')
                             }else if (response.status == '204') {
-                                alert("現在録画中のため、開始できません");
+                                alert("C110カメラは現在録画中です");
                                 this.isRecording=true;
+                                this.timeoutId = setTimeout(()=>{
+                                    this.requestRecStop();
+                                }, this.autoStopTime);
+                                console.log('c110 set timeout s:204')
                             }else{
-                                console.log('recording start failed.')
+                                console.log('c110 recording start failed.')
                             }
                         }).catch(err => {
-                            console.log('error occured:', err);
+                            console.log('c110 requestRecStart() error occured:', err);
                         });
                     }
                 },
                 requestRecStop(){
                     if (!this.isRecording) {
-                        console.log('now not recording!!')
+                        console.log('now not recording c110 !!')
                     } else {
-                        console.log('request stop recording')
+                        console.log('request stop recording c110')
                         axios
                         .get("control/record/stop?app=livecam&name=c110&rec=rec1")
                         .then(response => {
@@ -146,14 +162,20 @@
                             if (response.status == '200') {
                                 this.filename='';
                                 this.isRecording=false;
+                                clearTimeout(this.timeoutId);
+                                this.timeoutId = null;
+                                console.log('c110 clear timeout s:200')
                             }else if (response.status == '204') {
-                                alert("現在録画していないため、停止できません");
+                                alert("許容時間もしくは許容サイズを超えたため、C110カメラの録画を既に停止しました");
                                 this.isRecording=false;
+                                clearTimeout(this.timeoutId);
+                                this.timeoutId = null;
+                                console.log('c110 clear timeout s:204')
                             }else{
-                                console.log('recording stop failed.');
+                                console.log('c110 recording stop failed.');
                             }
                         }).catch(err => {
-                            console.log('error occured:', err);
+                            console.log('C110 requestRecStop() error occured:', err);
                         });
                     }
                 }
@@ -166,24 +188,15 @@
                     filename: "",
                     isRecording: false,
                     autoStopTime: 30000,
+                    timeoutId: null,
                 }
-            },
-            mounted () {
-                window.addEventListener('beforeunload', () => {
-                    this.requestRecStop()
-                })
-            },
-            destroyed () {
-                window.removeEventListener('beforeunload', () => {
-                    this.requestRecStop()
-                })
             },
             methods: {
                 requestRecStart(){
                     if (this.isRecording) {
-                        console.log('now recording!')
+                        console.log('now recording c200!')
                     } else {
-                        console.log('request start recording')
+                        console.log('request start recording c200')
                         axios
                         .get("control/record/start?app=livecam&name=c200&rec=rec1")
                         .then(response => {
@@ -192,25 +205,30 @@
                             if (response.status == '200') {
                                 this.filename=response.data;
                                 this.isRecording=true;
-                                setTimeout(()=>{
+                                this.timeoutId = setTimeout(()=>{
                                     this.requestRecStop();
                                 }, this.autoStopTime);
+                                console.log('c200 set timeout s:200')
                             }else if (response.status == '204') {
-                                alert("現在録画中のため、開始できません");
+                                alert("C200カメラは現在録画中です");
                                 this.isRecording=true;
+                                this.timeoutId = setTimeout(()=>{
+                                    this.requestRecStop();
+                                }, this.autoStopTime);
+                                console.log('c200 set timeout s:204')
                             }else{
-                                console.log('recording start failed.');
+                                console.log('c200 cording start failed.');
                             }
                         }).catch(err => {
-                            console.log('error occured:', err);
+                            console.log('c200 requestRecStart() error occured:', err);
                         });
                     }
                 },
                 requestRecStop(){
                     if (!this.isRecording) {
-                        console.log('now not recording!!')
+                        console.log('now not recording c200!!')
                     } else {
-                        console.log('request stop recording')
+                        console.log('request stop recording c200')
                         axios
                         .get("control/record/stop?app=livecam&name=c200&rec=rec1")
                         .then(response => {
@@ -219,14 +237,20 @@
                             if (response.status == '200') {
                                 this.filename='';
                                 this.isRecording=false;
+                                clearTimeout(this.timeoutId);
+                                this.timeoutId = null;
+                                console.log('c200 clear timeout s:200')
                             }else if (response.status == '204') {
-                                alert("現在録画していないため、停止できません");
+                                alert("許容時間もしくは許容サイズを超えたため、C200カメラの録画を既に停止しました");
                                 this.isRecording=false;
+                                clearTimeout(this.timeoutId);
+                                this.timeoutId = null;
+                                console.log('c200 clear timeout s:204')
                             }else{
-                                console.log('recording stop failed.');
+                                console.log('c200 recording stop failed.');
                             }
                         }).catch(err => {
-                            console.log('error occured:', err);
+                            console.log('c200 requestRecStop() error occured:', err);
                         });
                     }
                 }

--- a/nginx_rtmp/etc/nginx/conf/nginx.conf
+++ b/nginx_rtmp/etc/nginx/conf/nginx.conf
@@ -59,6 +59,7 @@ rtmp {
                 record_suffix -%Y%m%d%H%M%S.flv;
                 record_path /usr/share/nginx/html/hls;
                 record_unique on;
+                record_max_size 3M;
                 exec_record_done ffmpeg -i $path -vcodec copy $dirname/$basename.mp4;
             }
         }


### PR DESCRIPTION
# Purpose :
* close #12

# What was implemented :
* Processing of page transitions from the recording screen has been corrected.
* The following two bugs were found and fixed.
  * When a page transition was made to a link, etc., an error occurred in beforeunload.
  * Recording was stopped after 30 seconds at the start of recording, which could cause recording to stop unintentionally when the user returned after a page transition.
* In addition, the screen display was reviewed so that the user could see that recording was in progress.

# Checked :
* Screen display and operation of the recording button were confirmed when the screen was shifted during recording and the user came back to the screen.
  * before recording starts 
    ![pre_start](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/a13ae464-df5d-46ef-8aee-e6b39f1a0fd4)
  * after recording starts
  ![recording](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/616ef02f-fe8d-4569-a890-bd6fee487552)
  * When the link to the playback page of the recorded video is clicked
  ![goto_link](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/39033d7d-e915-4fa7-9229-5aa567ad3a4b)
  * after returning to the recording page
  ![back](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/e139961a-5248-427a-8eba-1b1266fb0150)
  * after clicking the Recording Start button
  ![recording_2](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/a60e8c5e-328b-4e68-a44b-4931ff28f0f2)
  * after clicking the OK button 
  ![recording_3](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/f8ac1ede-c21a-4dcc-8104-383a75e872d1)
  * When 30 seconds have elapsed from recording, or when the file size limit has been exceeded
  ![stop_recording](https://github.com/aktnk/HTTP-Live-Streaming-of-RTSP-cameras/assets/13390370/0b787eea-4a6e-4af2-8daa-ce633d3fe984)
